### PR TITLE
HHRE-683 minor updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ buildjar:  ## Updates all the packages using Pipfile # (it takes a long time) ma
 	mvn dependency:copy-dependencies -DoutputDirectory=target/jars -Dhttps.protocols=TLSv1.2
 
 .PHONY:loadfhir
-loadfhir: up
+loadfhir:
 	docker-compose run scriptrunner bash -c "pip install requests && ls / && cd /scripts && python3 load_fhir_server.py"
 
 .PHONY: clean_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   fhir:
     depends_on:
       - mongo
-    image: imranq2/node-fhir-server-mongo:2.0.84
+    image: imranq2/node-fhir-server-mongo:2.1.3
      # To use local fhir code, comment above line and uncomment below
 #    build:
 #        dockerfile: Dockerfile

--- a/src/test/java/com/bwell/services/spark/RunCqlLibraryUdfTest.java
+++ b/src/test/java/com/bwell/services/spark/RunCqlLibraryUdfTest.java
@@ -54,7 +54,7 @@ public class RunCqlLibraryUdfTest extends SharedJavaSparkContext {
         String cqllibraryVersion = "1.0.0";
         String terminologyUrl = "http://localhost:3000/4_0_0";
         String terminologyHeaders = "";
-        String cqlVariablesToReturn = "PatientId,InAgeCohort,InObservationCohort,InDemographic";
+        String cqlVariablesToReturn = "InAgeCohort,InObservationCohort,InDemographic";
 
         String command = String.format(
                 "runCqlLibrary('%s', '%s', '%s','%s','%s', '%s', '%s', %s, %s, %s)",
@@ -112,7 +112,7 @@ public class RunCqlLibraryUdfTest extends SharedJavaSparkContext {
         String cqllibraryVersion = "1.0.0";
         String terminologyUrl = "http://localhost:3000/4_0_0";
         String terminologyHeaders = "";
-        String cqlVariablesToReturn = "PatientId,InObservationCohort,InDemographic";
+        String cqlVariablesToReturn = "InObservationCohort,InDemographic";
 
         String command = String.format(
                 "runCqlLibrary('%s', '%s', '%s','%s','%s', '%s', '%s', %s, %s, %s)",


### PR DESCRIPTION
- separated `make loadfhir` from `make up`
- updated fhir server pkg to the same version `2.1.3` used in the helix.pipelines project, 
- removed the `PatientId` string from the `cqlVariablesToReturn` variable, as variable name`PatientId` is automatically added for results data view inside the `runCqlLibrary` method