### PR TITLE
MATO-244:Move bsights-engine-spark to self-hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted,dev-ue1]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted,dev-ue1]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Moveing bsights-engine-spark to self-hosted instance
https://icanbwell.atlassian.net/browse/MATO-244